### PR TITLE
Updates to client networking

### DIFF
--- a/lib/client/network.py
+++ b/lib/client/network.py
@@ -79,21 +79,9 @@ class GameClient(object):
             reactor.callLater(self.network_fps, self.eventTick)
 
 class ZombieClientProtocol(JsonReceiver):
-    # todo: move all potential client and server 'directives' (commands) to constants
-    # key_mapping = {
-    #     constants.STATE_ACTION: {
-    #         pygame.K_LEFT: 'left',
-    #         pygame.K_RIGHT: 'right',
-    #         pygame.K_z: 'jump',
-    #         pygame.K_ESCAPE: 'quit',
-    #     },
-    #     constants.STATE_WAITING: {
-    #         pygame.K_ESCAPE: 'quit',
-    #     },
-    # }
 
     def __init__(self, game_client):
-        self.game_client = game_client #TODO: do we need access to this?
+        self.game_client = game_client
         self.connected = False
 
     def connectionMade(self):

--- a/lib/client/network.py
+++ b/lib/client/network.py
@@ -1,10 +1,8 @@
 from twisted.internet import protocol
 from twisted.internet import reactor
 from ..shared.protocol import JsonReceiver
-from ..shared import constants
 from .. import settings
 from .game import Game
-import pygame
 import logging
 
 log = logging.getLogger(__name__)

--- a/lib/client/network.py
+++ b/lib/client/network.py
@@ -1,36 +1,104 @@
 from twisted.internet import protocol
+from twisted.internet import reactor
 from ..shared.protocol import JsonReceiver
 from ..shared import constants
 from .. import settings
 from .game import Game
 import pygame
+import logging
+
+log = logging.getLogger(__name__)
+
+class GameClient(object):
+
+    def __init__(self, game, factory):
+        log.info('Setup GameClient')
+        self.ticking = False
+        self.client = None
+
+        self.game = game
+        self.game.setup(self)
+
+        self.factory = factory
+
+        self.connection = None
+
+        self.fps = 1.0 / settings.FPS
+        self.network_fps = 1.0 / settings.NETWORK_FPS
+
+        self.command_queue = []
+
+    def command(self, command, **kwargs):
+        self.command_queue.append({
+            'command': command,
+            'kwargs': kwargs
+        });
+
+    def start(self):
+        log.info('Started GameClient')
+        self.ticking = True
+        self.tick()
+        self.eventTick()
+
+    def stop(self):
+        log.info('Stopping GameClient')
+        self.disconnect()
+        self.ticking = False
+        self.game.destroy()
+        reactor.stop()
+
+    def connect(self):
+        log.info('Connecting to server')
+        self.connection = reactor.connectTCP('localhost', settings.DEFAULT_PORT, self.factory)
+
+    def disconnect(self):
+        log.info('Disconnecting from server')
+        if self.connection:
+            self.connection.disconnect()
+            self.connection = None
+
+    def setClient(self, client):
+        self.client = client
+
+    def processEvents(self):
+        if self.command_queue:
+            if self.client:
+                self.client.sendCommand('commands', commands=self.command_queue)
+            else:
+                print 'WTF???'
+            self.command_queue = []
+
+    def tick(self):
+        if self.ticking:
+            self.game.gameLoop()
+            reactor.callLater(self.fps, self.tick)
+
+    def eventTick(self):
+        if self.ticking:
+            self.processEvents()
+            reactor.callLater(self.network_fps, self.eventTick)
 
 class ZombieClientProtocol(JsonReceiver):
     # todo: move all potential client and server 'directives' (commands) to constants
-    key_mapping = {
-        constants.STATE_ACTION: {
-            pygame.K_LEFT: 'left',
-            pygame.K_RIGHT: 'right',
-            pygame.K_z: 'jump',
-            pygame.K_ESCAPE: 'quit',
-        },
-        constants.STATE_WAITING: {
-            pygame.K_ESCAPE: 'quit',
-        },
-    }
+    # key_mapping = {
+    #     constants.STATE_ACTION: {
+    #         pygame.K_LEFT: 'left',
+    #         pygame.K_RIGHT: 'right',
+    #         pygame.K_z: 'jump',
+    #         pygame.K_ESCAPE: 'quit',
+    #     },
+    #     constants.STATE_WAITING: {
+    #         pygame.K_ESCAPE: 'quit',
+    #     },
+    # }
 
-    def __init__(self, game):
-        self.game = game
+    def __init__(self, game_client):
+        self.game_client = game_client #TODO: do we need access to this?
+        self.connected = False
 
     def connectionMade(self):
-        self.game.bindToClient(self.sendUserInput)
-
-    def sendUserInput(self, data):
-        if self.game.state == constants.STATE_INTRO:
-            self.sendCommand('salutation', name=data)
-        else:
-            if data in self.key_mapping[self.game.state]:
-                self.sendCommand(self.key_mapping[self.game.state][data])
+        self.connected = True
+        self.game_client.setClient(self)
 
     def sendCommand(self, command, **kwargs):
         self.sendObject(command=command, params=kwargs)
@@ -38,13 +106,15 @@ class ZombieClientProtocol(JsonReceiver):
 
 class ZombieClientFactory(protocol.ClientFactory):
     def __init__(self):
-        pygame.init()
-        screen = pygame.display.set_mode(settings.WINDOW_SIZE)
-        self.game = Game(screen)
-        self.game.start()
+        game = Game()
+
+        self.game_client = GameClient(game, self)
+        self.game_client.start()
+
+        self.game_client.connect()
 
     def buildProtocol(self, addr):
-        p = ZombieClientProtocol(self.game)
+        p = ZombieClientProtocol(self.game_client)
         p.factory = self
         return p
     

--- a/lib/main.py
+++ b/lib/main.py
@@ -12,16 +12,20 @@ log = logging.getLogger(__name__)
 
 def run_game():
     log.info('Starting server')
-    server = Process(target=server_process)
-    server.start()
-    try:
-        log.info('Starting pygame')
-        factory = ZombieClientFactory()
-        reactor.connectTCP('localhost', 10543, factory)
-        reactor.run()
+    # server = Process(target=server_process)
+    # server.start()
+    # try:
+    #     log.info('Starting game factory')
+    #     factory = ZombieClientFactory()
+    #     reactor.connectTCP('localhost', 10543, factory)
+    #     reactor.run()
 
-    finally:
-        server.terminate()  # not great longterm
+    # finally:
+    #     server.terminate()  # not great longterm
+
+    log.info('Starting game factory')
+    factory = ZombieClientFactory()
+    reactor.run()
 
 def run_server():
     server_process()

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -1,15 +1,24 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging.config
 import os
+from pygame.locals import * #this is potentially a little cluttery but allows us to define constants for controls
+from .shared import constants
 
 
 GAME_TITLE = "Zombie Brisket"
-WINDOW_SIZE = (600, 600)
-FPS = 60
+WINDOW_SIZE = (640, 480)
+FPS = 30
+NETWORK_FPS = 10 #how many times a second we send stuff to server
 DEFAULT_PORT = 10543
 DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'data')
 
 NUMBER_OF_PLAYERS = 2
+
+CONTROLS = {
+    K_LEFT: constants.PLAYER_MOVE_LEFT,
+    K_RIGHT: constants.PLAYER_MOVE_RIGHT,
+    K_z: constants.PLAYER_MOVE_JUMP
+}
 
 LOGGING = {
     'version': 1,

--- a/lib/shared/constants.py
+++ b/lib/shared/constants.py
@@ -3,3 +3,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 STATE_INTRO = 1
 STATE_WAITING = 2
 STATE_ACTION = 3
+
+
+#server actions
+PLAYER_MOVE_RIGHT = 'move_right'
+PLAYER_MOVE_LEFT = 'move_left'
+PLAYER_MOVE_JUMP = 'jump'

--- a/lib/shared/constants.py
+++ b/lib/shared/constants.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+#TODO: do we need these now?
 STATE_INTRO = 1
 STATE_WAITING = 2
 STATE_ACTION = 3


### PR DESCRIPTION
I commented out the code to auto start server for testing - can easily turn it on.

Eventually it will be handled in the client/networking.GameClient object to start server, and be responsible for tearing it down either way.

Updated client/game to separate the setup/networking from graphics code.

Quitting now cascades properly across everything.

Event loop and network event loop now work as expected and are configurable.
Keys are configurable in settings.py

@cciccia 
