### PR TITLE
Level loader update

### DIFF
--- a/data/entities/entities_processing.py
+++ b/data/entities/entities_processing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, json, print_function, unicode_literals
 
 
 def process_json(json_to_parse):
@@ -6,23 +6,24 @@ def process_json(json_to_parse):
     Takes json from the server or the client and xforms it into a logical entity and a graphical entity
     '''
 
-    logical_entity = LogicalEntity(json_to_parse.get('hit_box_size'), json_to_parse.get('state'))
-    graphical_entity = GraphicalEntity(json_to_parse.get('resource'))
+    # Allows for any number of properties to be defined within the configs
+    # which will be pulled into the entities' constructors.
+    logical_entity = LogicalEntity(json_to_parse.get('logicalConfig'))
+    graphical_entity = GraphicalEntity(json_to_parse.get('graphicalConfig'))
 
     return [logical_entity, graphical_entity]
 
 
 class LogicalEntity(object):
 
-    def __init__(self, hit_box_size, state):
-        # length and width of hit box
-        self.hit_box_size = hit_box_size
-        self.state = state
+    def __init__(self, config):
+        # Take the config and set the object to what is in the config
+        self.__dict__.update(config)
 
 
 class GraphicalEntity(object):
 
-    def __init__(self, resource):
-        # Was thinking resource should just be a string of a file location for an image? We can change later
-        self.resource = resource
+    def __init__(self, config):
+        # Take the config and set the object to what is in the config
+         self.__dict__.update(config)
 

--- a/lib/server/level_loader.py
+++ b/lib/server/level_loader.py
@@ -37,6 +37,12 @@ class LevelLoader(object):
     def parseConfig(self):
         config = json.loads(open(self.config_path, 'rb').read())
         self.level_name = config["levelName"]
+        # Determines if the level is single, coop or competitive
+        self.level_type = config["levelType"]
+        # Determines which background will be used
+        self.level_background = config["background"]
+        # Determines if this will use cavern, indoor, outdoor or w/e tiles
+        self.level_theme = config["theme"]
 
     def parseImage(self):
         self.image = pygame.image.load(self.image_path)


### PR DESCRIPTION
Adding in some changes to allow us to theme levels and add backgrounds, so that we don't have to have a bunch of extraneous pixel colors within the level map. I also made the entity processing more dynamic so that it can follow this kind of structure:

``` javascript
[{
  entityType: 'Tile',
  logicalConfig: {
    hit_box_size: [15,15],
    state: someStateThingy
},
  graphicalConfig: {
    image_path: 'some/sort/of/path.png',
    additionalProp: additionalValue
}
}]
```

The main reason that I am proposing this change is so that when we create a level, the tileset can have its `image_path` and a `tile_map` built into its GraphicalEntity, without us having to add a bunch of property mapping into the processor, i.e., not having to determine which properties are logical, graphical, or a subclass of logical or graphical, like LogicalZombie or GraphicalTile or the like. Instead, we could have an `entityType` property that defines the class, like Zombie or Tile, and then that class dictionary is built by the rest of the config. The entity that is built, then, can have a `logical_entity` property and a `graphical_entity` property.

If we do decide upon using this, then let me know, and I will change `process_json` to take in an instance, and it will place these new entities onto the instance.
